### PR TITLE
fix: 온보딩 버그 수정

### DIFF
--- a/src/pages/Auth/SignIn.tsx
+++ b/src/pages/Auth/SignIn.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import {
   OnBoarding,
   SignInBtns,
@@ -10,17 +10,25 @@ import useLoginCheck from '@/hooks/Auth/useLoginCheck';
 
 function SignIn() {
   useLoginCheck();
-  const onboarding = localStorage.getItem('onboarding');
-  if (!onboarding) localStorage.setItem('onboarding', 'true');
-  const [isOnboarding, setIsOnboarding] = useState<string | null>(onboarding);
+  const [isVisible, setIsVisible] = useState(true);
+
+  // useEffect를 쓰면 화면이 깜빡여서 useLayoutEffect로 변경
+  useLayoutEffect(() => {
+    // localStorage에서 'onboarding' 키를 확인
+    const onboarding = localStorage.getItem('onboarding');
+
+    // 'onboarding' 키가 없을 경우(처음 방문한 경우)에만 setIsVisible을 true로 설정
+    if (!onboarding) setIsVisible(true);
+    // 'onboarding' 키가 있을 경우에는 setIsVisible을 false로 설정하여 숨김
+    else setIsVisible(false);
+  }, []);
 
   const onCloseOnboarding = () => {
-    setIsOnboarding('false');
-    localStorage.setItem('onboarding', 'false');
+    setIsVisible(false);
+    localStorage.setItem('onboarding', 'hide');
   };
 
-  if (isOnboarding && JSON.parse(isOnboarding))
-    return <OnBoarding onCloseOnboarding={onCloseOnboarding} />;
+  if (isVisible) return <OnBoarding onCloseOnboarding={onCloseOnboarding} />;
   return (
     <Container>
       <SignInTitle />


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
close #124 

## 작업 내용 (변경 사항)
온보딩 페이지가 두 번째 접속시에 등장하는 버그가 있어서 로직을 수정했습니다.

## 스크린샷

## 트러블 슈팅
`localStorage`에 값을 저장할 때, true/false로 저장할 것이 아니라
아예 `localStorage`에 설정값을 넣고 빼고를 해야 했었습니다.

즉 앱을 처음 시작하면 화면이 나오고, 스킵 버튼을 눌러야 `localStorage`에 값을 저장해서
그다음 실행부터는 그 값이 있으면 무조건 로그인 화면으로 나오게 수정했습니다.

## 리뷰 요청 사항
