### PR TITLE
feat: 여행 후기 리스트 무한 스크롤 기능 구현, Spinner 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-router-dom": "^6.21.1",
     "react-sheet-slide": "^1.3.0",
     "react-sliding-pane": "^7.3.0",
+    "react-spinners": "^0.13.8",
     "react-youtube": "^10.1.0",
     "recoil": "^0.7.7",
     "styled-components": "^6.1.6",

--- a/src/apis/trip-records.ts
+++ b/src/apis/trip-records.ts
@@ -3,9 +3,17 @@ import client from './client';
 // 여행 후기 관련 API
 
 // 여행 후기 리스트 조회
-export const getTripRecords = async (param?: string) => {
+export const getTripRecords = async ({
+  pageParam = 0,
+  size = 5,
+  filter,
+}: {
+  pageParam?: number;
+  size?: number;
+  filter?: string;
+} = {}) => {
   const { data } = await client.get(
-    `v1/trip-records${param ? `?${param}` : ''}`,
+    `v1/trip-records?page=${pageParam}&size=${size}${filter ? `&${filter}` : ''}`,
   );
 
   return data.data;

--- a/src/components/Trip/TripHome/TripHomeBody/TripHomeBody.tsx
+++ b/src/components/Trip/TripHome/TripHomeBody/TripHomeBody.tsx
@@ -19,15 +19,15 @@ const TripHomeBody = () => {
     queries: [
       {
         queryKey: ['TripRecordsDefaultData'],
-        queryFn: () => getTripRecords('size=5'),
+        queryFn: () => getTripRecords(),
       },
       {
         queryKey: ['TripRecordsExpenseFilterData'],
-        queryFn: () => getTripRecords('size=5&expenseRangeType=100'),
+        queryFn: () => getTripRecords({ filter: 'expenseRangeType=100' }),
       },
       {
         queryKey: ['TripRecordsTotalDaysFilterData'],
-        queryFn: () => getTripRecords('size=5&totalDays=2'),
+        queryFn: () => getTripRecords({ filter: 'totalDays=2' }),
       },
       {
         queryKey: ['ShortsData'],

--- a/src/components/Trip/TripHome/TripHomeBody/TripHomeBody.tsx
+++ b/src/components/Trip/TripHome/TripHomeBody/TripHomeBody.tsx
@@ -40,8 +40,6 @@ const TripHomeBody = () => {
     navigate(`/trip/list?${param}`);
   };
 
-  console.log(ShortsData);
-
   return (
     <Styled.Container>
       <div>

--- a/src/components/Trip/TripList/CardList/CardList.tsx
+++ b/src/components/Trip/TripList/CardList/CardList.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import { TripCard } from '../..';
 import * as Styled from './CardList.styles';
 import { CardListProps } from './CardList.types';
@@ -5,14 +6,16 @@ import { CardListProps } from './CardList.types';
 const CardList = ({ tripRecordsData }: CardListProps) => {
   return (
     <Styled.Container>
-      {tripRecordsData?.pages.map((tripRecordArr: TripRecord[]) =>
-        tripRecordArr.map((tripRecordData: TripRecord) => (
-          <TripCard
-            key={tripRecordData.tripRecordId}
-            tripRecordData={tripRecordData}
-          />
-        )),
-      )}
+      {tripRecordsData?.pages.map((tripRecordArr: TripRecord[], index) => (
+        <Fragment key={index}>
+          {tripRecordArr.map((tripRecordData: TripRecord) => (
+            <TripCard
+              key={tripRecordData.tripRecordId}
+              tripRecordData={tripRecordData}
+            />
+          ))}
+        </Fragment>
+      ))}
     </Styled.Container>
   );
 };

--- a/src/components/Trip/TripList/CardList/CardList.tsx
+++ b/src/components/Trip/TripList/CardList/CardList.tsx
@@ -5,9 +5,14 @@ import { CardListProps } from './CardList.types';
 const CardList = ({ tripRecordsData }: CardListProps) => {
   return (
     <Styled.Container>
-      {tripRecordsData?.map((data) => (
-        <TripCard key={data.tripRecordId} tripRecordData={data} />
-      ))}
+      {tripRecordsData?.pages.map((tripRecordArr: TripRecord[]) =>
+        tripRecordArr.map((tripRecordData: TripRecord) => (
+          <TripCard
+            key={tripRecordData.tripRecordId}
+            tripRecordData={tripRecordData}
+          />
+        )),
+      )}
     </Styled.Container>
   );
 };

--- a/src/components/Trip/TripList/CardList/CardList.types.ts
+++ b/src/components/Trip/TripList/CardList/CardList.types.ts
@@ -1,3 +1,5 @@
+import { InfiniteData } from '@tanstack/react-query';
+
 export interface CardListProps {
-  tripRecordsData: TripRecord[];
+  tripRecordsData: InfiniteData<any, unknown> | undefined;
 }

--- a/src/components/common/Spinners/Spinners.styles.ts
+++ b/src/components/common/Spinners/Spinners.styles.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+import { alignCenter } from '@/styles/common';
+
+export const Wrapper = styled.div`
+  ${alignCenter};
+  justify-content: center;
+
+  width: 100%;
+  margin: 1rem 0;
+`;

--- a/src/components/common/Spinners/Spinners.tsx
+++ b/src/components/common/Spinners/Spinners.tsx
@@ -1,0 +1,12 @@
+import { ClipLoader } from 'react-spinners';
+import * as Styled from './Spinners.styles';
+
+const Spinners = () => {
+  return (
+    <Styled.Wrapper>
+      <ClipLoader color="#B4F34C" />
+    </Styled.Wrapper>
+  );
+};
+
+export default Spinners;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -24,3 +24,4 @@ export { default as EmptyContents } from '@/components/common/EmptyContents/Empt
 export { default as PlaceReviewCard } from '@/components/common/PlaceReviewCard/PlaceReviewCard';
 export { default as TripRecordReviewCard } from '@/components/common/TripRecordReviewCard/TripRecordReviewCard';
 export { default as Comment } from '@/components/common/Comment/Comment';
+export { default as Spinners } from '@/components/common/Spinners/Spinners';

--- a/src/pages/DetailFeed/Reviews/Reviews.tsx
+++ b/src/pages/DetailFeed/Reviews/Reviews.tsx
@@ -30,8 +30,6 @@ const Reviews = () => {
     refetch();
   }, [selectedFilter, onlyImage]);
 
-  console.log(placeReviewsData);
-
   return (
     <div>
       <Styled.NavWrap>

--- a/src/pages/Trip/TripDetail/TripDetail.tsx
+++ b/src/pages/Trip/TripDetail/TripDetail.tsx
@@ -43,7 +43,7 @@ const TripDetail = () => {
       },
       {
         queryKey: ['TripRecordsDefaultData'],
-        queryFn: () => getTripRecords('size=5'),
+        queryFn: () => getTripRecords(),
       },
     ],
   });

--- a/src/pages/Trip/TripList/TripList.tsx
+++ b/src/pages/Trip/TripList/TripList.tsx
@@ -55,7 +55,6 @@ const TripList = () => {
         )}
 
         <CardList tripRecordsData={tripRecordsData} />
-        {/* {tripRecordsData && } */}
         {isFetchingNextPage ? (
           <Spinners />
         ) : (

--- a/src/pages/Trip/TripList/TripList.tsx
+++ b/src/pages/Trip/TripList/TripList.tsx
@@ -1,6 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { Link, useSearchParams } from 'react-router-dom';
-import { SimpleNav, SubTitle, Text } from '@/components/common';
+import { useInView } from 'react-intersection-observer';
+import { useEffect } from 'react';
+import { SimpleNav, Spinners, SubTitle, Text } from '@/components/common';
 import * as Styled from './TripList.styles';
 import DollarIcon from '/images/dollar.svg';
 import StarIcon from '/starIcon.svg';
@@ -11,12 +13,29 @@ const TripList = () => {
   const [searchParams] = useSearchParams();
   const queryString = searchParams.toString();
   const category = queryString.split('=')[0];
-
-  const { data: tripRecordsData } = useQuery({
+  const [ref, inView] = useInView();
+  const {
+    data: tripRecordsData,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery({
     queryKey: ['TripRecordsData'],
-    queryFn: () => getTripRecords(queryString),
+    queryFn: ({ pageParam }) =>
+      getTripRecords({ pageParam, size: 10, filter: queryString }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      return lastPage.length !== 0 ? lastPageParam + 1 : null;
+    },
   });
 
+  useEffect(() => {
+    if (hasNextPage && inView) {
+      fetchNextPage();
+    }
+  }, [inView]);
+
+  console.log(tripRecordsData);
   return (
     <Styled.Container>
       <SimpleNav>검색</SimpleNav>
@@ -37,6 +56,12 @@ const TripList = () => {
         )}
 
         <CardList tripRecordsData={tripRecordsData} />
+        {/* {tripRecordsData && } */}
+        {isFetchingNextPage ? (
+          <Spinners />
+        ) : (
+          tripRecordsData && <div ref={ref} />
+        )}
       </Styled.MainContainer>
     </Styled.Container>
   );

--- a/src/pages/Trip/TripList/TripList.tsx
+++ b/src/pages/Trip/TripList/TripList.tsx
@@ -35,7 +35,6 @@ const TripList = () => {
     }
   }, [inView]);
 
-  console.log(tripRecordsData);
   return (
     <Styled.Container>
       <SimpleNav>검색</SimpleNav>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4847,6 +4847,11 @@ react-sliding-pane@^7.3.0:
     prop-types "^15.7.2"
     react-modal "^3.14.3"
 
+react-spinners@^0.13.8:
+  version "0.13.8"
+  resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.13.8.tgz#5262571be0f745d86bbd49a1e6b49f9f9cb19acc"
+  integrity sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"


### PR DESCRIPTION
## 🔎 작업 개요 (이슈 번호)
close #120 

## ⛏ 작업 내용 (변경 사항)
### 여행 후기 리스트 무한 스크롤 기능  구현
- 처음 여행 후기를 조회할 때 0페이지, 10개씩 조회합니다.
- 여행 후기가 총 몇 개고, 마지막 페이지인지 아닌지 알 수 있는 방법이 없어서 여행 후기를 계속 불러오다가, 불러온 데이터에 더 이상 여행 후기가 없을 때 `null`을 리턴하는 방식으로 구현했습니다.
![image](https://github.com/TripComeTrue/TripComeTrue_FE/assets/121606131/68c1c129-54d5-4c67-8fa9-c624cc84c7c3)
- 다음 페이지가 있고 `inView`에 도달했을 때 다음페이지 요청을 보냅니다.
![image](https://github.com/TripComeTrue/TripComeTrue_FE/assets/121606131/dc6ae5db-12a7-411f-9651-d167c6705e5a)
- 조건부를 통해 다음페이지를 불러오는 중일 때는 `Spinners` 컴포넌트가 나오도록 구현했습니다.
![image](https://github.com/TripComeTrue/TripComeTrue_FE/assets/121606131/52a933a0-925b-4a78-be46-fff7f84651e7)

## 📸 스크린샷
https://github.com/TripComeTrue/TripComeTrue_FE/assets/121606131/10272d9a-f4c2-46ef-b87f-6b2702c04f92

## 💡 트러블 슈팅

## 🙋‍♂️ 리뷰 요청 사항
