### PR TITLE
refactor: 여행지 리뷰 에러 핸들링 및 Suspense와 ErrorBoundary 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-sheet-slide": "^1.3.0",
     "react-sliding-pane": "^7.3.0",
     "react-spinners": "^0.13.8",
+    "react-toastify": "^10.0.4",
     "react-youtube": "^10.1.0",
     "recoil": "^0.7.7",
     "styled-components": "^6.1.6",

--- a/src/@types/place.ts
+++ b/src/@types/place.ts
@@ -7,16 +7,17 @@ interface PlaceReviewsData {
 }
 
 interface PlaceReviewData {
-  amILike: boolean;
-  commentCount: number;
-  content: string;
-  createdAt: string;
-  likeCount: number;
+  placeReviewId: number;
   memberId: number;
   nickname: string;
-  placeReviewId: number;
-  imageUrl: string;
   profileUrl: string;
+  imageUrl: string;
+  content: string;
+  likeCount: number;
+  createdAt: string;
+  amILike: boolean;
+  commentCount: number;
+  comments: CommentData;
 }
 
 interface CommentData {

--- a/src/@types/place.ts
+++ b/src/@types/place.ts
@@ -17,7 +17,7 @@ interface PlaceReviewData {
   createdAt: string;
   amILike: boolean;
   commentCount: number;
-  comments: CommentData;
+  comments: CommentData[];
 }
 
 interface CommentData {

--- a/src/@types/response.types.ts
+++ b/src/@types/response.types.ts
@@ -1,0 +1,8 @@
+interface ErrorData {
+  errorMessage: string;
+}
+
+interface Response<T = ErrorData> {
+  code: number;
+  data: T;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { Route, Routes, useLocation } from 'react-router-dom';
-import { useLayoutEffect } from 'react';
+import { Suspense, useLayoutEffect } from 'react';
 import DashBoard from '@/components/layout';
 import {
   TripDetail,
@@ -56,6 +56,7 @@ import TripPlanSelect from './pages/Trip/TripPlan/TripPlanSelect';
 import { HomeAllCity } from './components/Home';
 import SearchTagExpense from './pages/Search/SearchTagExpense';
 import TripPlanCopy from './pages/Trip/TripPlan/TripPlanCopy';
+import { Spinners } from './components/common';
 
 function App() {
   const location = useLocation();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { Route, Routes, useLocation } from 'react-router-dom';
-import { Suspense, useLayoutEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import DashBoard from '@/components/layout';
 import {
   TripDetail,
@@ -56,7 +56,6 @@ import TripPlanSelect from './pages/Trip/TripPlan/TripPlanSelect';
 import { HomeAllCity } from './components/Home';
 import SearchTagExpense from './pages/Search/SearchTagExpense';
 import TripPlanCopy from './pages/Trip/TripPlan/TripPlanCopy';
-import { Spinners } from './components/common';
 
 function App() {
   const location = useLocation();

--- a/src/apis/place.ts
+++ b/src/apis/place.ts
@@ -3,14 +3,14 @@
 import client from './client';
 
 // 특정 여행지에 대한 리뷰 작성
-export const postPlaceReview = async (
+export const postPlaceReview = (
   placeId: string,
   reviewData: { imageUrl: string; content: string },
-) => {
-  const res = await client.post(`v1/places/${placeId}/reviews`, reviewData);
-
-  return res;
-};
+) =>
+  client.post<Response<PlaceReviewData>>(
+    `v1/places/${placeId}/reviews`,
+    reviewData,
+  );
 
 // 특정 여행지에 대한 다수의 리뷰 조회
 export const getPlaceReviews = async ({
@@ -57,7 +57,9 @@ export const putPlaceReview = async (
 
 // 특정 여행지에 대한 리뷰 1건 조회
 export const getPlaceReview = async (placeReviewId: string) => {
-  const { data } = await client.get(`v1/places/reviews/${placeReviewId}`);
+  const { data } = await client.get<Response<PlaceReviewData>>(
+    `v1/places/reviews/${placeReviewId}`,
+  );
 
   return data.data;
 };

--- a/src/apis/place.ts
+++ b/src/apis/place.ts
@@ -26,7 +26,7 @@ export const getPlaceReviews = async ({
   pageParam?: number;
   size?: number;
 }) => {
-  const { data } = await client.get<{ code: number; data: PlaceReviewsData }>(
+  const { data } = await client.get<Response<PlaceReviewsData>>(
     `v1/places/${placeId}/reviews?page=${pageParam}&size=${size}&${
       sort === '추천순' ? 'sort=likeCount' : 'sort=createdAt'
     },desc&onlyImage=${onlyImage}`,

--- a/src/components/DetailFeed/CommentList/CommentList.styles.ts
+++ b/src/components/DetailFeed/CommentList/CommentList.styles.ts
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+import { alignCenter, flexColumn } from '@/styles/common';
+
+export const CommentContainer = styled.div`
+  ${flexColumn};
+  gap: 0.5rem;
+
+  margin-bottom: 4.625rem;
+  padding: 0.75rem 0;
+`;
+
+export const CommentTitle = styled.div`
+  font-size: 0.75rem;
+  font-weight: 700;
+
+  color: ${({ theme }) => theme.text.gray};
+  padding: 0 1.25rem;
+`;
+
+export const Header = styled.div`
+  ${alignCenter}
+`;
+
+export const EmptyComment = styled.div`
+  ${alignCenter};
+  justify-content: center;
+`;
+
+export const EmptyText = styled.span`
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #bebebe;
+`;

--- a/src/components/DetailFeed/CommentList/CommentList.tsx
+++ b/src/components/DetailFeed/CommentList/CommentList.tsx
@@ -1,0 +1,101 @@
+import { useMutation } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import { toast } from 'react-toastify';
+import { Comment } from '@/components/common';
+import * as Styled from './CommentList.styles';
+import { deletePlaceReviewComment } from '@/apis/place';
+import { CommentListProps } from './CommentList.types';
+
+const CommentList = ({
+  replyClickHandler,
+  placeReviewData,
+  placeReviewRefetch,
+}: CommentListProps) => {
+  const { mutate: deleteCommentMutate } = useMutation({
+    mutationFn: (deleteCommentId: number) =>
+      deletePlaceReviewComment(deleteCommentId),
+    onSuccess: () => {
+      placeReviewRefetch();
+    },
+    onError: (error) => {
+      if (isAxiosError(error))
+        if (error.response?.status === 404 || error.response?.status === 400)
+          toast.error(error.response.data?.errorMessage, {
+            position: 'top-center',
+            autoClose: 5000,
+          });
+    },
+  });
+
+  return (
+    <Styled.CommentContainer>
+      <Styled.CommentTitle>
+        댓글 {placeReviewData.commentCount}
+      </Styled.CommentTitle>
+      {placeReviewData.comments.length !== 0 ? (
+        <ul>
+          {placeReviewData.comments.map((commentData: CommentData) => (
+            <li key={commentData.commentId}>
+              <Comment>
+                <Comment.CommentCard>
+                  <Styled.Header>
+                    <Comment.Info
+                      isWriter={commentData.isWriter}
+                      profileUrl={commentData.profileUrl}
+                      nickname={commentData.nickname}
+                      createdAt={commentData.createdAt}
+                    />
+                    {commentData.isWriter && (
+                      <Comment.ActionsModal
+                        onClickDelete={() =>
+                          deleteCommentMutate(commentData.commentId)
+                        }
+                      />
+                    )}
+                  </Styled.Header>
+                  <Comment.Content content={commentData.content} />
+                  <Comment.ReplyButton
+                    onClickFunc={() => replyClickHandler(commentData.commentId)}
+                    replyLength={commentData.replyComments.length}
+                  />
+                </Comment.CommentCard>
+              </Comment>
+              <ul>
+                {commentData.replyComments.map((replyData: ReplyData) => (
+                  <li key={replyData.commentId}>
+                    <Comment>
+                      <Comment.ReplyCard>
+                        <Styled.Header>
+                          <Comment.Info
+                            isWriter={replyData.isWriter}
+                            profileUrl={replyData.profileUrl}
+                            nickname={replyData.nickname}
+                            createdAt={replyData.createdAt}
+                          />
+                          {replyData.isWriter && (
+                            <Comment.ActionsModal
+                              onClickDelete={() =>
+                                deleteCommentMutate(replyData.commentId)
+                              }
+                            />
+                          )}
+                        </Styled.Header>
+                        <Comment.Content content={replyData.content} />
+                      </Comment.ReplyCard>
+                    </Comment>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <Styled.EmptyComment>
+          <Styled.EmptyText>첫 댓글을 달아보세요</Styled.EmptyText>
+        </Styled.EmptyComment>
+      )}
+    </Styled.CommentContainer>
+  );
+};
+
+export default CommentList;

--- a/src/components/DetailFeed/CommentList/CommentList.types.ts
+++ b/src/components/DetailFeed/CommentList/CommentList.types.ts
@@ -1,0 +1,9 @@
+import { QueryObserverResult, RefetchOptions } from '@tanstack/react-query';
+
+export interface CommentListProps {
+  replyClickHandler: (id: number) => void;
+  placeReviewData: PlaceReviewData;
+  placeReviewRefetch: (
+    options?: RefetchOptions | undefined,
+  ) => Promise<QueryObserverResult<PlaceReviewData, Error>>;
+}

--- a/src/components/DetailFeed/ReviewCommentMain/ReviewCommentMain.tsx
+++ b/src/components/DetailFeed/ReviewCommentMain/ReviewCommentMain.tsx
@@ -1,0 +1,45 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import { getPlaceReview } from '@/apis/place';
+import CommentList from '../CommentList/CommentList';
+import ReviewDetail from '../ReviewDetail/ReviewDetail';
+import { ReviewCommentMainProps } from './ReviewCommentMain.types';
+
+const ReviewCommentMain = ({
+  replyClickHandler,
+  commentClickHandler,
+  setRefetch,
+}: ReviewCommentMainProps) => {
+  const { reviewId } = useParams() as {
+    placeId: string;
+    reviewId: string;
+  };
+  const { data: placeReviewData, refetch: placeReviewRefetch } =
+    useSuspenseQuery({
+      queryKey: ['PlaceReviewData'],
+      queryFn: () => getPlaceReview(reviewId),
+    });
+
+  useEffect(() => {
+    setRefetch(() => placeReviewRefetch);
+  }, [placeReviewRefetch]);
+
+  return (
+    <div>
+      <ReviewDetail
+        placeReviewData={placeReviewData}
+        placeReviewRefetch={placeReviewRefetch}
+        commentClickHandler={commentClickHandler}
+      />
+
+      <CommentList
+        placeReviewData={placeReviewData}
+        placeReviewRefetch={placeReviewRefetch}
+        replyClickHandler={replyClickHandler}
+      />
+    </div>
+  );
+};
+
+export default ReviewCommentMain;

--- a/src/components/DetailFeed/ReviewCommentMain/ReviewCommentMain.types.ts
+++ b/src/components/DetailFeed/ReviewCommentMain/ReviewCommentMain.types.ts
@@ -1,0 +1,5 @@
+export interface ReviewCommentMainProps {
+  replyClickHandler: (id: number) => void;
+  commentClickHandler: VoidFunction;
+  setRefetch: React.Dispatch<React.SetStateAction<VoidFunction | null>>;
+}

--- a/src/components/DetailFeed/ReviewDetail/ReviewDetail.styles.ts
+++ b/src/components/DetailFeed/ReviewDetail/ReviewDetail.styles.ts
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+import { alignCenter, flexColumn } from '@/styles/common';
+
+export const ReviewContainer = styled.div`
+  ${flexColumn};
+  gap: 0.625rem;
+
+  padding: 1.25rem;
+  border-bottom: 1px solid ${({ theme }) => theme.brand.lightGray};
+`;
+
+export const ReviewInfo = styled.div`
+  ${alignCenter};
+  justify-content: space-between;
+`;
+
+export const ReviewImage = styled.img`
+  width: 100%;
+  height: 11.25rem;
+  border-radius: 0.625rem;
+
+  object-fit: cover;
+  object-position: center;
+`;
+
+export const Creator = styled.div`
+  ${alignCenter};
+  gap: 0.5rem;
+`;
+
+export const InteractionButtons = styled.div`
+  ${alignCenter};
+  gap: 1.125rem;
+`;
+export const LikeButton = styled.div`
+  ${alignCenter};
+  gap: 0.25rem;
+
+  padding: 0.125rem 0.375rem;
+  border-radius: 1.875rem;
+  background-color: ${({ theme }) => theme.brand.lightGray};
+  cursor: pointer;
+`;
+export const CommentButton = styled.div`
+  ${alignCenter};
+  gap: 0.25rem;
+
+  cursor: pointer;
+`;

--- a/src/components/DetailFeed/ReviewDetail/ReviewDetail.tsx
+++ b/src/components/DetailFeed/ReviewDetail/ReviewDetail.tsx
@@ -1,0 +1,89 @@
+import { useMutation } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import { toast } from 'react-toastify';
+import { Avatar, Text } from '@/components/common';
+import * as Styled from './ReviewDetail.styles';
+import FormattedDate from '@/utils/formattedDate';
+import LikeIcon from '/images/like.svg';
+import CommentIcon from '/images/comment.svg';
+import { deleteLike, postLike } from '@/apis/place';
+import { ReviewDetailProps } from './ReviewDetail.types';
+
+const ReviewDetail = ({
+  placeReviewData,
+  commentClickHandler,
+  placeReviewRefetch,
+}: ReviewDetailProps) => {
+  const { mutate: deleteLikeMutate } = useMutation({
+    mutationFn: (placeReviewId: number) => deleteLike(placeReviewId),
+    onSuccess: () => placeReviewRefetch(),
+    onError: (error) => {
+      if (isAxiosError(error))
+        if (error.response?.status === 404)
+          toast.error(error.response.data?.errorMessage, {
+            position: 'top-center',
+            autoClose: 5000,
+          });
+    },
+  });
+  const { mutate: postLikeMutate } = useMutation({
+    mutationFn: (placeReviewId: number) => postLike(placeReviewId),
+    onSuccess: () => placeReviewRefetch(),
+    onError: (error) => {
+      if (isAxiosError(error))
+        if (error.response?.status === 409)
+          toast.error(error.response.data?.errorMessage, {
+            position: 'top-center',
+            autoClose: 5000,
+          });
+    },
+  });
+
+  const onClickLikeButton = (amILike: boolean, id: number): void => {
+    if (amILike) return deleteLikeMutate(id);
+
+    return postLikeMutate(id);
+  };
+
+  return (
+    <Styled.ReviewContainer>
+      <Styled.ReviewInfo>
+        <Styled.Creator>
+          <Avatar src={placeReviewData.profileUrl} size={32} />
+          <Text fontWeight={700}>{placeReviewData.nickname}</Text>
+        </Styled.Creator>
+        <Text fontSize={10} fontWeight={700}>
+          {FormattedDate(placeReviewData?.createdAt || '')}
+        </Text>
+      </Styled.ReviewInfo>
+      <div>
+        <Styled.ReviewImage src={placeReviewData.imageUrl} alt="리뷰" />
+        <Text>{placeReviewData.content}</Text>
+      </div>
+      <Styled.InteractionButtons>
+        <Styled.LikeButton
+          onClick={() =>
+            onClickLikeButton(
+              placeReviewData.amILike,
+              placeReviewData.placeReviewId,
+            )
+          }>
+          <img src={LikeIcon} alt="like icon" />
+          <Text fontSize={12} fontWeight={700} color="gray">
+            {placeReviewData.likeCount}
+          </Text>
+        </Styled.LikeButton>
+        <Styled.CommentButton onClick={commentClickHandler}>
+          <img src={CommentIcon} alt="comment icon" />
+          <Text fontSize={12} fontWeight={700} color="gray">
+            {placeReviewData.commentCount
+              ? placeReviewData.commentCount
+              : '댓글 달기'}
+          </Text>
+        </Styled.CommentButton>
+      </Styled.InteractionButtons>
+    </Styled.ReviewContainer>
+  );
+};
+
+export default ReviewDetail;

--- a/src/components/DetailFeed/ReviewDetail/ReviewDetail.types.ts
+++ b/src/components/DetailFeed/ReviewDetail/ReviewDetail.types.ts
@@ -1,0 +1,9 @@
+import { QueryObserverResult, RefetchOptions } from '@tanstack/react-query';
+
+export interface ReviewDetailProps {
+  placeReviewData: PlaceReviewData;
+  commentClickHandler: VoidFunction;
+  placeReviewRefetch: (
+    options?: RefetchOptions | undefined,
+  ) => Promise<QueryObserverResult<PlaceReviewData, Error>>;
+}

--- a/src/components/DetailFeed/ReviewList/ReviewList.tsx
+++ b/src/components/DetailFeed/ReviewList/ReviewList.tsx
@@ -1,0 +1,74 @@
+import { Fragment, useEffect } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { useInView } from 'react-intersection-observer';
+import { PlaceReviewCard, Spinners } from '@/components/common';
+import FormattedDate from '@/utils/formattedDate';
+import { getPlaceReviews } from '@/apis/place';
+
+const ReviewList = ({ sort, onlyImage }: any) => {
+  const [ref, inView] = useInView();
+  const { placeId } = useParams() as { placeId: string };
+
+  const {
+    data: placeReviewsData,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    refetch,
+  } = useSuspenseInfiniteQuery({
+    queryKey: ['PlaceReviewsInfiniteData'],
+    queryFn: ({ pageParam }) =>
+      getPlaceReviews({ placeId, size: 10, sort, onlyImage, pageParam }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      return !lastPage.isLast ? lastPageParam + 1 : null;
+    },
+  });
+
+  useEffect(() => {
+    refetch();
+  }, [sort, onlyImage]);
+
+  useEffect(() => {
+    if (hasNextPage && inView) {
+      fetchNextPage();
+    }
+  }, [inView]);
+
+  return (
+    <>
+      <ul>
+        {placeReviewsData?.pages.map((page, index) => (
+          <Fragment key={index}>
+            {page.placeReviews.map((placeReview) => (
+              <li key={placeReview.placeReviewId}>
+                <Link
+                  to={`/detailfeed/spot/${placeId}/review/${placeReview.placeReviewId}/comment`}>
+                  <PlaceReviewCard>
+                    <PlaceReviewCard.PlaceHeader
+                      nickname={placeReview.nickname}
+                      profileUrl={placeReview.profileUrl}
+                      writeDate={FormattedDate(placeReview.createdAt)}
+                    />
+                    <PlaceReviewCard.Main
+                      imageUrl={placeReview.imageUrl}
+                      content={placeReview.content}
+                    />
+                    <PlaceReviewCard.InteractionButtons
+                      likeCount={placeReview.likeCount}
+                      commentCount={placeReview.commentCount}
+                    />
+                  </PlaceReviewCard>
+                </Link>
+              </li>
+            ))}
+          </Fragment>
+        ))}
+      </ul>
+      {isFetchingNextPage ? <Spinners /> : <div ref={ref} />}
+    </>
+  );
+};
+
+export default ReviewList;

--- a/src/components/DetailFeed/index.ts
+++ b/src/components/DetailFeed/index.ts
@@ -12,3 +12,4 @@ export { default as CityGallery } from './Gallery/CityGallery';
 export { default as RecommendSpot } from './RecommendSpot/RecommendSpot';
 export { default as PlaceReviews } from './PlaceReviews/PlaceReviews';
 export { default as SearchedSpot } from './SearchedSpot/SearchedSpot';
+export { default as ReviewList } from './ReviewList/ReviewList';

--- a/src/components/DetailFeed/index.ts
+++ b/src/components/DetailFeed/index.ts
@@ -13,3 +13,4 @@ export { default as RecommendSpot } from './RecommendSpot/RecommendSpot';
 export { default as PlaceReviews } from './PlaceReviews/PlaceReviews';
 export { default as SearchedSpot } from './SearchedSpot/SearchedSpot';
 export { default as ReviewList } from './ReviewList/ReviewList';
+export { default as ReviewCommentMain } from './ReviewCommentMain/ReviewCommentMain';

--- a/src/components/common/ReviewWrite/ReviewWrite.tsx
+++ b/src/components/common/ReviewWrite/ReviewWrite.tsx
@@ -88,7 +88,7 @@ const Write = ({
         여행 후기에 대해 남기고 싶은 말을 남겨주세요
       </SubTitle>
       <Styled.TextArea
-        maxLength={2000}
+        maxLength={500}
         cols={3}
         placeholder="여행 후기를 참고한 경험을 솔직하게 남겨주세요"
         defaultValue={defaultValue}
@@ -99,7 +99,7 @@ const Write = ({
           {defaultValue ? defaultValue.length : content?.length}
         </Text>
         <Text color="gray" fontSize={10}>
-          &nbsp;/&nbsp;2000
+          &nbsp;/&nbsp;500
         </Text>
       </Styled.TextCountWrapper>
     </Styled.WriteContainer>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,13 @@ import { BrowserRouter } from 'react-router-dom';
 import ReactDOM from 'react-dom/client';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ThemeProvider } from 'styled-components';
+import { ThemeProvider, css } from 'styled-components';
+import { ToastContainer } from 'react-toastify';
 import theme from '@/styles/theme';
 import App from './App';
 import '@/styles/fonts/font.css';
 import '@/styles/index.css';
+import 'react-toastify/dist/ReactToastify.css';
 // import worker from './mocks/browser';
 
 const queryClient = new QueryClient({
@@ -29,6 +31,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       <BrowserRouter>
         <React.StrictMode>
           <ThemeProvider theme={theme}>
+            <ToastContainer toastClassName="toastify" />
             <App />
           </ThemeProvider>
         </React.StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import ReactDOM from 'react-dom/client';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ThemeProvider, css } from 'styled-components';
+import { ThemeProvider } from 'styled-components';
 import { ToastContainer } from 'react-toastify';
 import theme from '@/styles/theme';
 import App from './App';

--- a/src/pages/DetailFeed/PlaceReview/PlaceReviewEdit.tsx
+++ b/src/pages/DetailFeed/PlaceReview/PlaceReviewEdit.tsx
@@ -1,8 +1,8 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import axios from 'axios';
 import { toast } from 'react-toastify';
+import { isAxiosError } from 'axios';
 import { ReviewWrite } from '@/components/common';
 import { getPlaceReview, putPlaceReview } from '@/apis/place';
 import useDeleteImages from '@/hooks/common/useDeleteImages';
@@ -35,7 +35,7 @@ const PlaceReviewEdit = () => {
       navigate(`/detailfeed/spot/${placeId}/review`);
     },
     onError: (error) => {
-      if (axios.isAxiosError(error))
+      if (isAxiosError(error))
         if (error.response?.status === 400 || error.response?.status === 404) {
           toast.error(error.response.data?.errorMessage, {
             position: 'top-center',

--- a/src/pages/DetailFeed/PlaceReview/PlaceReviewWrite.tsx
+++ b/src/pages/DetailFeed/PlaceReview/PlaceReviewWrite.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
+import axios from 'axios';
+import { toast } from 'react-toastify';
 import { ReviewWrite } from '@/components/common';
 import { postPlaceReview } from '@/apis/place';
 import useSubmitImages from '@/hooks/common/useSubmitImages';
@@ -18,13 +20,32 @@ const PlaceReviewWrite = () => {
     }: {
       imageUrl: string;
       contentValue: string;
-    }) => postPlaceReview(placeId, { imageUrl, content: contentValue }),
+    }) => {
+      return postPlaceReview(placeId, {
+        imageUrl,
+        content: contentValue,
+      });
+    },
+    onSuccess: () => navigate(`/detailfeed/spot/${placeId}/review`),
+    onError: (error) => {
+      if (axios.isAxiosError(error))
+        if (error.response?.status === 409) {
+          toast.error(error.response.data?.errorMessage, {
+            position: 'top-center',
+            autoClose: 5000,
+          });
+        } else if (error.response?.status === 400) {
+          toast.error(error.response.data?.errorMessage, {
+            position: 'top-center',
+            autoClose: 5000,
+          });
+        }
+    },
   });
 
   const onClickPostReview = async () => {
     const res = await handleSubmitImages();
     postReviewMutate({ imageUrl: res[0], contentValue: content });
-    navigate(`/detailfeed/spot/${placeId}/review`);
   };
 
   return (

--- a/src/pages/DetailFeed/PlaceReview/PlaceReviewWrite.tsx
+++ b/src/pages/DetailFeed/PlaceReview/PlaceReviewWrite.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
-import axios from 'axios';
 import { toast } from 'react-toastify';
+import { isAxiosError } from 'axios';
 import { ReviewWrite } from '@/components/common';
 import { postPlaceReview } from '@/apis/place';
 import useSubmitImages from '@/hooks/common/useSubmitImages';
@@ -28,7 +28,7 @@ const PlaceReviewWrite = () => {
     },
     onSuccess: () => navigate(`/detailfeed/spot/${placeId}/review`),
     onError: (error) => {
-      if (axios.isAxiosError(error))
+      if (isAxiosError(error))
         if (error.response?.status === 409) {
           toast.error(error.response.data?.errorMessage, {
             position: 'top-center',

--- a/src/pages/DetailFeed/Reviews/Reviews.tsx
+++ b/src/pages/DetailFeed/Reviews/Reviews.tsx
@@ -4,7 +4,6 @@ import * as Styled from './Reviews.styles';
 import BackArrow from '@/assets/back-arrow.svg';
 import WriteIcon from '/images/write.svg';
 import { Bubble, Filter, RetryErrorBoundary, Text } from '@/components/common';
-
 import ReviewsSkeleton from './ReviewsSkeleton';
 import { ReviewList } from '@/components/DetailFeed';
 

--- a/src/pages/DetailFeed/Reviews/Reviews.tsx
+++ b/src/pages/DetailFeed/Reviews/Reviews.tsx
@@ -1,52 +1,18 @@
-import { Fragment, useEffect, useState } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { Suspense, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { useInView } from 'react-intersection-observer';
 import * as Styled from './Reviews.styles';
 import BackArrow from '@/assets/back-arrow.svg';
 import WriteIcon from '/images/write.svg';
-import {
-  Bubble,
-  Filter,
-  PlaceReviewCard,
-  Spinners,
-  Text,
-} from '@/components/common';
-import { getPlaceReviews } from '@/apis/place';
-import FormattedDate from '@/utils/formattedDate';
+import { Bubble, Filter, RetryErrorBoundary, Text } from '@/components/common';
+
 import ReviewsSkeleton from './ReviewsSkeleton';
+import { ReviewList } from '@/components/DetailFeed';
 
 const Reviews = () => {
   const navigate = useNavigate();
   const { placeId } = useParams() as { placeId: string };
   const [sort, setSort] = useState('최신순');
   const [onlyImage, setOnlyImage] = useState(false);
-  const [ref, inView] = useInView();
-  const {
-    data: placeReviewsData,
-    hasNextPage,
-    isFetchingNextPage,
-    fetchNextPage,
-    refetch,
-  } = useInfiniteQuery({
-    queryKey: ['PlaceReviewsInfiniteData'],
-    queryFn: ({ pageParam }) =>
-      getPlaceReviews({ placeId, size: 10, sort, onlyImage, pageParam }),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, _, lastPageParam) => {
-      return !lastPage.isLast ? lastPageParam + 1 : null;
-    },
-  });
-
-  useEffect(() => {
-    refetch();
-  }, [sort, onlyImage]);
-
-  useEffect(() => {
-    if (hasNextPage && inView) {
-      fetchNextPage();
-    }
-  }, [inView]);
 
   return (
     <div>
@@ -54,9 +20,7 @@ const Reviews = () => {
         <Styled.NavBackBtn onClick={() => navigate(-1)}>
           <img src={BackArrow} alt="뒤로가기" />
         </Styled.NavBackBtn>
-        <Styled.NavTitle>
-          리뷰({placeReviewsData?.pages[0].totalCount})
-        </Styled.NavTitle>
+        <Styled.NavTitle>리뷰</Styled.NavTitle>
         <Styled.WriteBtnWrapper>
           <Link to={`/detailfeed/spot/${placeId}/review/write`}>
             <Styled.WriteBtn src={WriteIcon} alt="리뷰 작성 아이콘" />
@@ -82,41 +46,12 @@ const Reviews = () => {
             setSelectedFilter={setSort}
           />
         </Styled.Header>
-        {placeReviewsData ? (
-          <>
-            <ul>
-              {placeReviewsData?.pages.map((page, index) => (
-                <Fragment key={index}>
-                  {page.placeReviews.map((placeReview) => (
-                    <li key={placeReview.placeReviewId}>
-                      <Link
-                        to={`/detailfeed/spot/${placeId}/review/${placeReview.placeReviewId}/comment`}>
-                        <PlaceReviewCard>
-                          <PlaceReviewCard.PlaceHeader
-                            nickname={placeReview.nickname}
-                            profileUrl={placeReview.profileUrl}
-                            writeDate={FormattedDate(placeReview.createdAt)}
-                          />
-                          <PlaceReviewCard.Main
-                            imageUrl={placeReview.imageUrl}
-                            content={placeReview.content}
-                          />
-                          <PlaceReviewCard.InteractionButtons
-                            likeCount={placeReview.likeCount}
-                            commentCount={placeReview.commentCount}
-                          />
-                        </PlaceReviewCard>
-                      </Link>
-                    </li>
-                  ))}
-                </Fragment>
-              ))}
-            </ul>
-            {isFetchingNextPage ? <Spinners /> : <div ref={ref} />}
-          </>
-        ) : (
-          <ReviewsSkeleton />
-        )}
+
+        <RetryErrorBoundary>
+          <Suspense fallback={<ReviewsSkeleton />}>
+            <ReviewList sort={sort} onlyImage={onlyImage} />
+          </Suspense>
+        </RetryErrorBoundary>
       </Styled.Container>
     </div>
   );

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -171,3 +171,9 @@ input:focus {
 button {
   cursor: pointer;
 }
+
+.toastify {
+  font-family: 'AppleSDGothicNeo', 'SF-Pro', sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4852,6 +4852,13 @@ react-spinners@^0.13.8:
   resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.13.8.tgz#5262571be0f745d86bbd49a1e6b49f9f9cb19acc"
   integrity sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==
 
+react-toastify@^10.0.4:
+  version "10.0.4"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-10.0.4.tgz#6ecdbbf923a07fc45850e69b0566efc7bf733283"
+  integrity sha512-etR3RgueY8pe88SA67wLm8rJmL1h+CLqUGHuAoNsseW35oTGJEri6eBTyaXnFKNQ80v/eO10hBYLgz036XRGgA==
+  dependencies:
+    clsx "^2.1.0"
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"


### PR DESCRIPTION
## 🔎 작업 개요 (이슈 번호)
close #164 

## 📝 작업 내용 (변경 사항)
### 여행지 리뷰 관련 에러 핸들링
- 여행지 리뷰 관련 useMutation 사용 시 실패했을 경우를 대비해 에러 핸들링을 추가했습니다.
![image](https://github.com/TripComeTrue/TripComeTrue_FE/assets/121606131/efcfb70b-a994-43e3-bc40-a9bd8cbb195f)

### API Response 타입 추가
- api 요청 시 제네릭으로 응답값의 타입을 지정해주어 추론이 가능하도록 했습니다.
![image](https://github.com/TripComeTrue/TripComeTrue_FE/assets/121606131/67329e32-0751-4617-b31b-ed9888a3589f)

### Suspense와 ErrorBoundary 추가
- 기존의 코드와는 달리 성공 사례의 경우에만 집중할 수 있도록 Suspense와 ErrorBoundary를 구현했습니다.
(기존 코드)
![image](https://github.com/TripComeTrue/TripComeTrue_FE/assets/121606131/2bf11785-d855-4849-9a90-38d615a65b77)
  - 기존의 코드에선 조건부를 통해 스켈레톤 UI를 보여주기 때문에 코드의 가독성이 좋지 않습니다.
 (현재 코드)
![image](https://github.com/TripComeTrue/TripComeTrue_FE/assets/121606131/b598d016-8b50-4ce9-ab89-9dacec4447a1)
  - 현재의 코드에서는 list컴포넌트를 분리하고 Suspense와 ErrorBoundary를 적용 시켜줌으로써 더 간결하게 로딩과 실패의 경우를 구현하였습니다.


## 📸 스크린샷

## 💡 트러블 슈팅

## 🙋‍♂️ 리뷰 요청 사항
