### PR TITLE
refactor: 여행 후기 저장 기능, 리뷰 좋아요 기능 Optimistic UI 적용

### DIFF
--- a/src/components/DetailFeed/ReviewDetail/ReviewDetail.tsx
+++ b/src/components/DetailFeed/ReviewDetail/ReviewDetail.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { toast } from 'react-toastify';
 import { Avatar, Text } from '@/components/common';
@@ -14,10 +14,29 @@ const ReviewDetail = ({
   commentClickHandler,
   placeReviewRefetch,
 }: ReviewDetailProps) => {
+  const queryClient = useQueryClient();
   const { mutate: deleteLikeMutate } = useMutation({
     mutationFn: (placeReviewId: number) => deleteLike(placeReviewId),
+    onMutate: () => {
+      const prevPlaceReviewData = queryClient.getQueryData(['PlaceReviewData']);
+      const nextPlaceReviewData = {
+        ...placeReviewData,
+        amILike: !placeReviewData.amILike,
+        likeCount: placeReviewData.amILike
+          ? placeReviewData.likeCount - 1
+          : placeReviewData.likeCount + 1,
+      };
+
+      queryClient.setQueryData(['PlaceReviewData'], nextPlaceReviewData);
+
+      return { prevPlaceReviewData };
+    },
     onSuccess: () => placeReviewRefetch(),
-    onError: (error) => {
+    onError: (error, _, context) => {
+      queryClient.setQueryData(
+        ['PlaceReviewData'],
+        context?.prevPlaceReviewData,
+      );
       if (isAxiosError(error))
         if (error.response?.status === 404)
           toast.error(error.response.data?.errorMessage, {
@@ -28,8 +47,26 @@ const ReviewDetail = ({
   });
   const { mutate: postLikeMutate } = useMutation({
     mutationFn: (placeReviewId: number) => postLike(placeReviewId),
+    onMutate: () => {
+      const prevPlaceReviewData = queryClient.getQueryData(['PlaceReviewData']);
+      const nextPlaceReviewData = {
+        ...placeReviewData,
+        amILike: !placeReviewData.amILike,
+        likeCount: placeReviewData.amILike
+          ? placeReviewData.likeCount - 1
+          : placeReviewData.likeCount + 1,
+      };
+
+      queryClient.setQueryData(['PlaceReviewData'], nextPlaceReviewData);
+
+      return { prevPlaceReviewData };
+    },
     onSuccess: () => placeReviewRefetch(),
-    onError: (error) => {
+    onError: (error, _, context) => {
+      queryClient.setQueryData(
+        ['PlaceReviewData'],
+        context?.prevPlaceReviewData,
+      );
       if (isAxiosError(error))
         if (error.response?.status === 409)
           toast.error(error.response.data?.errorMessage, {

--- a/src/components/Trip/TripDetail/ReviewAlert/ReviewAlert.tsx
+++ b/src/components/Trip/TripDetail/ReviewAlert/ReviewAlert.tsx
@@ -15,7 +15,7 @@ const ReviewAlert = () => {
   });
 
   const { imageUrl, nickname, ratingScore, content, tripRecordReviewId } =
-    tripRecordLatestReviewData.latestTripRecordReview;
+    tripRecordLatestReviewData.latestTripRecordReview || '';
 
   useEffect(() => {
     tripRecordLatestReviewRefetch();

--- a/src/components/Trip/TripHome/TripCard/TripCard.tsx
+++ b/src/components/Trip/TripHome/TripCard/TripCard.tsx
@@ -8,8 +8,8 @@ import { TripCardProps } from './TripCard.types';
 
 const TripCard = ({ size = 152, tripRecordData }: TripCardProps) => {
   const stringifiedSize = pxToRem(size);
-  const formatDays = `${tripRecordData.totalDays}박 ${
-    tripRecordData.totalDays + 1
+  const formatDays = `${tripRecordData.totalDays - 1}박 ${
+    tripRecordData.totalDays
   }일`;
   const [mainCountries, ...countries] = tripRecordData.countries.split(',');
   const formatCountries =

--- a/src/components/Trip/TripHome/TripCard/TripCard.types.ts
+++ b/src/components/Trip/TripHome/TripCard/TripCard.types.ts
@@ -1,4 +1,4 @@
 export interface TripCardProps {
-  tripRecordData: TripRecord;
+  tripRecordData: TripRecordData;
   size?: number;
 }

--- a/src/components/Trip/TripHome/TripCarousel/TripCarousel.types.ts
+++ b/src/components/Trip/TripHome/TripCarousel/TripCarousel.types.ts
@@ -1,4 +1,4 @@
 export interface TripCarouselProps {
-  tripRecordsData: TripRecord[];
+  tripRecordsData: TripRecordData[];
   size?: number;
 }

--- a/src/components/Trip/TripList/CardList/CardList.tsx
+++ b/src/components/Trip/TripList/CardList/CardList.tsx
@@ -1,22 +1,53 @@
-import { Fragment } from 'react';
+import { Fragment, useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'react-router-dom';
 import { TripCard } from '../..';
 import * as Styled from './CardList.styles';
-import { CardListProps } from './CardList.types';
+import { getTripRecords } from '@/apis/trip-records';
+import { Spinners } from '@/components/common';
 
-const CardList = ({ tripRecordsData }: CardListProps) => {
+const CardList = () => {
+  const [searchParams] = useSearchParams();
+  const queryString = searchParams.toString();
+  const [ref, inView] = useInView();
+  const {
+    data: tripRecordsData,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useSuspenseInfiniteQuery({
+    queryKey: ['TripRecordsData'],
+    queryFn: ({ pageParam }) =>
+      getTripRecords({ pageParam, size: 10, filter: queryString }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      return lastPage.length !== 0 ? lastPageParam + 1 : null;
+    },
+  });
+
+  useEffect(() => {
+    if (hasNextPage && inView) {
+      fetchNextPage();
+    }
+  }, [inView]);
+
   return (
-    <Styled.Container>
-      {tripRecordsData?.pages.map((tripRecordArr: TripRecord[], index) => (
-        <Fragment key={index}>
-          {tripRecordArr.map((tripRecordData: TripRecord) => (
-            <TripCard
-              key={tripRecordData.tripRecordId}
-              tripRecordData={tripRecordData}
-            />
-          ))}
-        </Fragment>
-      ))}
-    </Styled.Container>
+    <>
+      <Styled.Container>
+        {tripRecordsData.pages.map((page, index) => (
+          <Fragment key={index}>
+            {page.map((tripRecordData) => (
+              <TripCard
+                key={tripRecordData.tripRecordId}
+                tripRecordData={tripRecordData}
+              />
+            ))}
+          </Fragment>
+        ))}
+      </Styled.Container>
+      {isFetchingNextPage ? <Spinners /> : tripRecordsData && <div ref={ref} />}
+    </>
   );
 };
 

--- a/src/components/Trip/TripRecordReview/Edit/Edit.tsx
+++ b/src/components/Trip/TripRecordReview/Edit/Edit.tsx
@@ -1,0 +1,109 @@
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import { MouseEvent, useState } from 'react';
+import { isAxiosError } from 'axios';
+import { toast } from 'react-toastify';
+import { getTripRecordReview, putTripRecordReview } from '@/apis/trip-records';
+import { ReviewWrite } from '@/components/common';
+import useDeleteImages from '@/hooks/common/useDeleteImages';
+import useSubmitImages from '@/hooks/common/useSubmitImages';
+
+const Edit = () => {
+  const navigate = useNavigate();
+  const [files, setFiles] = useState<File[]>([]);
+  const [content, setContent] = useState('');
+  const [rating, setRating] = useState(0);
+  const { reviewId } = useParams() as { reviewId: string };
+  const { handleDeleteImages } = useDeleteImages();
+  const { handleSubmitImages } = useSubmitImages(files, setFiles);
+  const { data: tripRecordReviewData } = useSuspenseQuery({
+    queryKey: ['TripRecordReviewData'],
+    queryFn: () => getTripRecordReview(reviewId),
+  });
+
+  const onClickRating = (event: MouseEvent<HTMLSpanElement>): void => {
+    event.stopPropagation();
+    const target = event.target as HTMLSpanElement;
+    const ratingScore = Number(target.innerText.split(' ')[0]);
+
+    if (ratingScore) {
+      setRating(ratingScore);
+    }
+  };
+  const { mutate: putReviewMutate } = useMutation({
+    mutationFn: ({
+      imageUrl,
+      contentValue,
+      ratingScore,
+    }: {
+      imageUrl: string;
+      contentValue: string;
+      ratingScore: number;
+    }) =>
+      putTripRecordReview(reviewId, {
+        imageUrl,
+        content: contentValue,
+        ratingScore,
+      }),
+    onSuccess: () => {
+      navigate(-1);
+    },
+    onError: (error) => {
+      if (isAxiosError(error))
+        if (error.response?.status === 400 || error.response?.status === 404) {
+          toast.error(error.response.data?.errorMessage, {
+            position: 'top-center',
+            autoClose: 5000,
+          });
+        }
+    },
+  });
+
+  const onClickPutReview = async () => {
+    if (files.length !== 0) {
+      if (tripRecordReviewData.imageUrl)
+        handleDeleteImages([tripRecordReviewData.imageUrl]);
+      const res = await handleSubmitImages();
+      putReviewMutate({
+        imageUrl: res[0],
+        contentValue: content || tripRecordReviewData.content,
+        ratingScore: rating || tripRecordReviewData.ratingScore,
+      });
+    } else {
+      putReviewMutate({
+        imageUrl: tripRecordReviewData.imageUrl,
+        contentValue: content || tripRecordReviewData.content,
+        ratingScore: rating || tripRecordReviewData.ratingScore,
+      });
+    }
+  };
+
+  return (
+    <ReviewWrite>
+      <ReviewWrite.Nav title="리뷰 수정하기" />
+      <ReviewWrite.Image
+        imageUrl={tripRecordReviewData.imageUrl}
+        setFiles={setFiles}
+      />
+      <ReviewWrite.Write
+        defaultValue={tripRecordReviewData.content}
+        content={content}
+        setContent={setContent}
+      />
+      <ReviewWrite.Rating
+        myRatingScore={tripRecordReviewData.ratingScore}
+        rating={rating}
+        onClickFunc={onClickRating}
+      />
+      <ReviewWrite.EditButton
+        files={files}
+        content={content}
+        rating={rating}
+        title="리뷰 수정하기"
+        onClickFunc={onClickPutReview}
+      />
+    </ReviewWrite>
+  );
+};
+
+export default Edit;

--- a/src/components/Trip/TripRecordReview/Write/Write.tsx
+++ b/src/components/Trip/TripRecordReview/Write/Write.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import { isAxiosError } from 'axios';
+import { toast } from 'react-toastify';
+import { ReviewWrite } from '@/components/common';
+import { putTripRecordReviewContent } from '@/apis/trip-records';
+import useSubmitImages from '@/hooks/common/useSubmitImages';
+
+const Write = () => {
+  const navigate = useNavigate();
+  const { reviewId } = useParams() as {
+    reviewId: string;
+    tripRecordId: string;
+  };
+  const [files, setFiles] = useState<File[]>([]);
+  const [content, setContent] = useState('');
+  const { handleSubmitImages } = useSubmitImages(files, setFiles);
+  const { mutate: putReviewContentsMutate } = useMutation({
+    mutationFn: ({
+      imageUrl,
+      contentValue,
+    }: {
+      imageUrl: string;
+      contentValue: string;
+    }) =>
+      putTripRecordReviewContent(reviewId, { imageUrl, content: contentValue }),
+    onSuccess: () => {
+      navigate(-1);
+    },
+    onError: (error) => {
+      if (isAxiosError(error))
+        if (error.response?.status === 400 || error.response?.status === 404) {
+          toast.error(error.response.data?.errorMessage, {
+            position: 'top-center',
+            autoClose: 5000,
+          });
+        }
+    },
+  });
+
+  const onClickPutReviewContents = async () => {
+    const res = await handleSubmitImages();
+    putReviewContentsMutate({ imageUrl: res[0], contentValue: content });
+  };
+
+  return (
+    <ReviewWrite>
+      <ReviewWrite.Nav title="리뷰 작성하기" />
+      <ReviewWrite.Image setFiles={setFiles} />
+      <ReviewWrite.Write content={content} setContent={setContent} />
+      <ReviewWrite.WriteButton
+        files={files}
+        content={content}
+        title="리뷰 작성하기"
+        onClickFunc={onClickPutReviewContents}
+      />
+    </ReviewWrite>
+  );
+};
+
+export default Write;

--- a/src/components/Trip/index.ts
+++ b/src/components/Trip/index.ts
@@ -14,3 +14,7 @@ export { default as TripDetailMainSkeleton } from '@/components/Trip/TripDetail/
 export { default as ReviewAlert } from '@/components/Trip/TripDetail/ReviewAlert/ReviewAlert';
 export { default as ReviewAlertSkeleton } from '@/components/Trip/TripDetail/ReviewAlert/ReviewAlertSkeleton';
 export { default as TripComment } from '@/components/Trip/TripDetail/TripComment/TripComment';
+
+// TripRecordReview
+export { default as Edit } from '@/components/Trip/TripRecordReview/Edit/Edit';
+export { default as Write } from '@/components/Trip/TripRecordReview/Write/Write';

--- a/src/components/common/Spinners/Spinners.styles.ts
+++ b/src/components/common/Spinners/Spinners.styles.ts
@@ -6,5 +6,6 @@ export const Wrapper = styled.div`
   justify-content: center;
 
   width: 100%;
+  height: 100%;
   margin: 1rem 0;
 `;

--- a/src/pages/Trip/TripRecordReview/TripRecordReviewEdit.tsx
+++ b/src/pages/Trip/TripRecordReview/TripRecordReviewEdit.tsx
@@ -1,97 +1,14 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { useNavigate, useParams } from 'react-router-dom';
-import { MouseEvent, useState } from 'react';
-import { getTripRecordReview, putTripRecordReview } from '@/apis/trip-records';
-import { ReviewWrite } from '@/components/common';
-import useDeleteImages from '@/hooks/common/useDeleteImages';
-import useSubmitImages from '@/hooks/common/useSubmitImages';
+import { Suspense } from 'react';
+import { Edit } from '@/components/Trip';
+import { RetryErrorBoundary, Spinners } from '@/components/common';
 
 const TripRecordReviewEdit = () => {
-  const navigate = useNavigate();
-  const [files, setFiles] = useState<File[]>([]);
-  const [content, setContent] = useState('');
-  const [rating, setRating] = useState(0);
-  const { reviewId } = useParams() as { reviewId: string };
-  const { handleDeleteImages } = useDeleteImages();
-  const { handleSubmitImages } = useSubmitImages(files, setFiles);
-  const { data: tripRecordReviewData } = useQuery({
-    queryKey: ['TripRecordReviewData'],
-    queryFn: () => getTripRecordReview(reviewId),
-  });
-
-  const onClickRating = (event: MouseEvent<HTMLSpanElement>): void => {
-    event.stopPropagation();
-    const target = event.target as HTMLSpanElement;
-    const ratingScore = Number(target.innerText.split(' ')[0]);
-
-    if (ratingScore) {
-      setRating(ratingScore);
-    }
-  };
-  const { mutate: putReviewMutate } = useMutation({
-    mutationFn: ({
-      imageUrl,
-      contentValue,
-      ratingScore,
-    }: {
-      imageUrl: string;
-      contentValue: string;
-      ratingScore: number;
-    }) =>
-      putTripRecordReview(reviewId, {
-        imageUrl,
-        content: contentValue,
-        ratingScore,
-      }),
-    onSuccess: () => {
-      navigate(-1);
-    },
-  });
-
-  const onClickPutReview = async () => {
-    if (files.length !== 0) {
-      if (tripRecordReviewData?.imageUrl)
-        handleDeleteImages([tripRecordReviewData?.imageUrl]);
-      const res = await handleSubmitImages();
-      putReviewMutate({
-        imageUrl: res[0],
-        contentValue: content || tripRecordReviewData?.content,
-        ratingScore: rating || tripRecordReviewData?.ratingScore,
-      });
-    } else {
-      putReviewMutate({
-        imageUrl: tripRecordReviewData?.imageUrl,
-        contentValue: content || tripRecordReviewData?.content,
-        ratingScore: rating || tripRecordReviewData?.ratingScore,
-      });
-    }
-  };
-
   return (
-    <ReviewWrite>
-      <ReviewWrite.Nav title="리뷰 수정하기" />
-      <ReviewWrite.Image
-        imageUrl={tripRecordReviewData?.imageUrl}
-        setFiles={setFiles}
-      />
-      <ReviewWrite.Write
-        defaultValue={tripRecordReviewData?.content}
-        content={content}
-        setContent={setContent}
-      />
-      <ReviewWrite.Rating
-        myRatingScore={tripRecordReviewData?.ratingScore}
-        rating={rating}
-        onClickFunc={onClickRating}
-      />
-      <ReviewWrite.EditButton
-        files={files}
-        content={content}
-        rating={rating}
-        title="리뷰 수정하기"
-        onClickFunc={onClickPutReview}
-      />
-    </ReviewWrite>
+    <RetryErrorBoundary>
+      <Suspense fallback={<Spinners />}>
+        <Edit />
+      </Suspense>
+    </RetryErrorBoundary>
   );
 };
 

--- a/src/pages/Trip/TripRecordReview/TripRecordReviewWrite.tsx
+++ b/src/pages/Trip/TripRecordReview/TripRecordReviewWrite.tsx
@@ -1,51 +1,7 @@
-import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
-import { useNavigate, useParams } from 'react-router-dom';
-import { ReviewWrite } from '@/components/common';
-import { putTripRecordReviewContent } from '@/apis/trip-records';
-import useSubmitImages from '@/hooks/common/useSubmitImages';
+import { Write } from '@/components/Trip';
 
 const TripRecordReviewWrite = () => {
-  const navigate = useNavigate();
-  const { reviewId } = useParams() as {
-    reviewId: string;
-    tripRecordId: string;
-  };
-  const [files, setFiles] = useState<File[]>([]);
-  const [content, setContent] = useState('');
-  const { handleSubmitImages } = useSubmitImages(files, setFiles);
-  const { mutate: putReviewContentsMutate } = useMutation({
-    mutationFn: ({
-      imageUrl,
-      contentValue,
-    }: {
-      imageUrl: string;
-      contentValue: string;
-    }) =>
-      putTripRecordReviewContent(reviewId, { imageUrl, content: contentValue }),
-    onSuccess: () => {
-      navigate(-1);
-    },
-  });
-
-  const onClickPutReviewContents = async () => {
-    const res = await handleSubmitImages();
-    putReviewContentsMutate({ imageUrl: res[0], contentValue: content });
-  };
-
-  return (
-    <ReviewWrite>
-      <ReviewWrite.Nav title="리뷰 작성하기" />
-      <ReviewWrite.Image setFiles={setFiles} />
-      <ReviewWrite.Write content={content} setContent={setContent} />
-      <ReviewWrite.WriteButton
-        files={files}
-        content={content}
-        title="리뷰 작성하기"
-        onClickFunc={onClickPutReviewContents}
-      />
-    </ReviewWrite>
-  );
+  return <Write />;
 };
 
 export default TripRecordReviewWrite;


### PR DESCRIPTION
## 🔎 작업 개요 (이슈 번호)
close #173

## 📝 작업 내용 (변경 사항)
### 여행 후기 저장 기능, 여행지 리뷰 좋아요 기능 Optimistic Updates 적용
**적용 전**
![옵티미스틱 UI 적용 전](https://github.com/TripComeTrue/TripComeTrue_FE/assets/121606131/51e636ad-8de4-424e-8fc4-7481360127b8)
Optimistic Updates를 적용 하기 전에는 사용자의 네트워크 속도에 따라 UI 반영이 느리기 때문에 네트워크 상태가 좋지 않은 사용자한테는 좋지 않은 경험을 가져다줄 수 있을 것 같다고 생각했습니다.
**적용 후**
![옵티미스틱 UI 적용 후](https://github.com/TripComeTrue/TripComeTrue_FE/assets/121606131/3f20b20b-6733-4fae-95ff-8ebebb75dc97)
Optimistic Updates를 적용하여 일단 무조건 성공한다는 가정 하에 API와 상관없이 화면에 UI를 먼저 반영해줘서 사용자 경험을 향상시켰습니다.
- Optimistic Updates는 react-query를 통해 구현했습니다.
![image](https://github.com/TripComeTrue/TripComeTrue_FE/assets/121606131/e7e41aa7-9cd0-4f3c-9b25-df1e49c84daa)
- 업데이트할 데이터인 `nextTripRecordData`를 `setQueryData`로 API 요청을 통해 받아온 원래 데이터와 바꿔줍니다.
- 데이터가 바뀌면 재랜더링이 되기 때문에 바뀐 데이터가 바로 UI에 반영되고, 그 후 API 요청을 하게 됩니다.
- 만약 API 요청이 실패했다면 다시 원래 데이터로 바꿔야 하기 때문에 `onMutate`에서 `return`한 `prevTripRecordData`를 `setQueryData`를 사용하여 바꿔줍니다.

## 📸 스크린샷

## 💡 트러블 슈팅

## 🙋‍♂️ 리뷰 요청 사항
